### PR TITLE
sklearn to scikit-learn (package rename)

### DIFF
--- a/xx-sklearn-abalone.ipynb
+++ b/xx-sklearn-abalone.ipynb
@@ -36,11 +36,11 @@
      "source": [
       "First install `scikit-learn` with `conda` (recommended) or `pip`:\n",
       "\n",
-      "    conda install sklearn\n",
+      "    conda install scikit-learn\n",
       "\n",
       "or:\n",
       "\n",
-      "    pip install sklearn"
+      "    pip install scikit-learn"
      ]
     },
     {


### PR DESCRIPTION
We just used this in a SWC workshop in Berkeley - the import name is scikit-learn for pip and conda.
