### PR TITLE
Update link to instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,10 @@ You also agree to abide by our
 2.  For our lessons,
     you should branch from and submit pull requests against the `gh-pages` branch.
 
-3.  When editing lesson pages, you need only commit changes to the Markdown source files.
+3.  When editing lessons, please only commit changes to the Markdown
+    files, *not* the generated HTML.  We will re-create the HTML after
+    your pull request is merged.  (Working this way ensures that each
+    change only needs to be reviewed once, in one place.)
 
 4.  If you're looking for things to work on,
     please see [the list of issues for this repository][issues],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+Software Carpentry is an open source project,
+and we welcome contributions of all kinds:
+new lessons,
+fixes to existing material,
+bug reports,
+and reviews of proposed changes are all equally welcome.
+
+By contributing,
+you are agreeing that Software Carpentry may redistribute your work under
+[these licenses][license].
+You also agree to abide by our
+[contributor code of conduct][conduct].
+
+## Getting Started
+
+1.  We use GitHub flow to manage changes,
+    which is explained in the chapter [Contributing to a Project][pro-git-chapter]
+    in Scott Chacon's book *Pro Git*.
+
+2.  For our lessons,
+    you should branch from and submit pull requests against the `gh-pages` branch.
+
+3.  When editing lesson pages, you need only commit changes to the Markdown source files.
+
+4.  If you're looking for things to work on,
+    please see [the list of issues for this repository][issues],
+    or for [our other lessons][swc-lessons].
+    Comments on issues and reviews of pull requests are equally welcome.
+
+## Other Resources
+
+1.  This lesson is based on the template found at
+    [https://github.com/swcarpentry/lesson-template](https://github.com/swcarpentry/lesson-template).
+    That repository has instructions on formatting and previewing lessons.
+
+2.  For a list of helpful commands run `make` in this directory.
+
+[conduct]: CONDUCT.md
+[issues]: https://github.com/swcarpentry/python-intermediate-mosquitoes/issues
+[license]: LICENSE.md
+[pro-git-chapter]: http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project
+[swc-lessons]: http://software-carpentry.org/lessons.html

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# python-intermediate-mosquitoes
+python-intermediate-mosquitoes
+==============================
+
 Intermediate lesson on Python using mosquito data
+
+> Please see [https://github.com/swcarpentry/lesson-template](https://github.com/swcarpentry/lesson-template)
+> for instructions on formatting, building, and submitting lessons,
+> or run `make` in this directory for a list of helpful commands.


### PR DESCRIPTION
Pointing at lesson-example instead of lesson-template, and telling people (again) not to commit HTML.
